### PR TITLE
経験値システム(+アイテムが飛び回るクソ環境)改善完了

### DIFF
--- a/Assets/Scriptable Object/Characters/Fuko.asset
+++ b/Assets/Scriptable Object/Characters/Fuko.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
     moveSpeed: 5
     might: 1
     speed: 1
-    magnet: 30
+    magnet: 1

--- a/Assets/Scriptable Object/Characters/Memori.asset
+++ b/Assets/Scriptable Object/Characters/Memori.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
     moveSpeed: 5
     might: 1
     speed: 1
-    magnet: 30
+    magnet: 1

--- a/Assets/Scriptable Object/Characters/Nere.asset
+++ b/Assets/Scriptable Object/Characters/Nere.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
     moveSpeed: 5
     might: 1
     speed: 1
-    magnet: 30
+    magnet: 1

--- a/Assets/Scriptable Object/Characters/Sukauto.asset
+++ b/Assets/Scriptable Object/Characters/Sukauto.asset
@@ -22,4 +22,4 @@ MonoBehaviour:
     moveSpeed: 5
     might: 1
     speed: 1
-    magnet: 30
+    magnet: 1

--- a/Assets/Scriptable Object/Passive Items/Pummarola.asset
+++ b/Assets/Scriptable Object/Passive Items/Pummarola.asset
@@ -36,7 +36,7 @@ MonoBehaviour:
       speed: 0
       magnet: 0
   growth:
-  - name: Level 2
+  - name: "\u30CF\u30FC\u30C8\u306E\u30DA\u30F3\u30C0\u30F3\u30C8 Lv.2"
     description: "\u3082\u3063\u3068\u56DE\u5FA9"
     boosts:
       maxHealth: 0

--- a/Assets/Scriptable Object/Passive Items/Sofuken Battery.asset
+++ b/Assets/Scriptable Object/Passive Items/Sofuken Battery.asset
@@ -26,12 +26,12 @@ MonoBehaviour:
       speed: 0
       magnet: 0
   growth:
-  - name: Level 2
-    description: Gives more muscle.
+  - name: "\u7956\u7236\u72AC\u30D0\u30C3\u30C6\u30EA\u30FC Lv.2"
+    description: "\u66F4\u306B\u653B\u6483\u529B\u30A2\u30C3\u30D7"
     boosts:
       maxHealth: 0
       recovery: 0
       moveSpeed: 0
-      might: 0.1
+      might: 0.4
       speed: 0
       magnet: 0

--- a/Assets/Scriptable Object/Passive Items/Wings.asset
+++ b/Assets/Scriptable Object/Passive Items/Wings.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
       speed: 0
       magnet: 0
   growth:
-  - name: Level 2
+  - name: "\u7FFC Lv.2"
     description: "\u3055\u3089\u306B\u5411\u3053\u3046\u3078!!"
     boosts:
       maxHealth: 0


### PR DESCRIPTION
magnet=0だと吸収不可
magnet=1にしたら元通りになりましたわ^^
経験値だけじゃなく、他のアイテムが飛び回ることも同時に改善されたはず
ちな経験値やアイテムが飛び回っていた頃はmagnet=30