### PR TITLE
武器進化システムを旭祭仕様に

### DIFF
--- a/Assets/Scripts/Passive Items/Item.cs
+++ b/Assets/Scripts/Passive Items/Item.cs
@@ -72,8 +72,9 @@ public abstract class Item : MonoBehaviour
     // the weapons that are supposed to be consumed.
     public virtual bool AttemptEvolution(ItemData.Evolution evolutionData, int levelUpAmount = 0)
     {
-        if (!CanEvolve(evolutionData, levelUpAmount))
-            return false;
+        /*if (!CanEvolve(evolutionData, levelUpAmount))
+            return false;*/
+        if (currentLevel < maxLevel) return true;
 
         // Should we consume passives / weapons?
         //bool consumePassives = (evolutionData.consumes & ItemData.Evolution.Consumption.passives) > 0;
@@ -109,6 +110,9 @@ public abstract class Item : MonoBehaviour
     // Whenever an item levels up, attempt to make it evolve.
     public virtual bool DoLevelUp()
     {
+
+        bool evolved = false;
+
         if (evolutionData == null) return true;
 
         // Tries to evolve into every listed evolution of this weapon,
@@ -116,8 +120,13 @@ public abstract class Item : MonoBehaviour
         foreach (ItemData.Evolution e in evolutionData)
         {
             if (e.condition == ItemData.Evolution.Condition.auto)
-                AttemptEvolution(e);
-                //inventory.AddEvolutionWeapon(e.outcome.itemType);
+                evolved = AttemptEvolution(e) || evolved;
+            //inventory.AddEvolutionWeapon(e.outcome.itemType);
+        }
+
+        if (!evolved)
+        {
+            return true;
         }
 
         // Weapon Evolution logic will go here later.

--- a/Assets/Scripts/Player/PlayerInventory.cs
+++ b/Assets/Scripts/Player/PlayerInventory.cs
@@ -368,6 +368,11 @@ public class PlayerInventory : MonoBehaviour
                             upgradeOption.upgradeDescriptionDisplay.text = nextLevel.description;
                             upgradeOption.upgradeNameDisplay.text = nextLevel.name;
                             upgradeOption.upgradeIcon.sprite = chosenWeaponUpgrade.icon;
+                            if (w.currentLevel == w.maxLevel - 1) {
+                                Debug.LogWarning(string.Format("{0}は進化できるよ", chosenWeaponUpgrade.name));
+                                upgradeOption.upgradeButton.onClick.AddListener(() =>  w.DoLevelUp()); 
+                            }
+                            else Debug.LogWarning(string.Format("レベル{0}だと{1}は進化できないよ", w.currentLevel, chosenWeaponUpgrade.name));
                             isLevelUp = true;
                             break;
                         }
@@ -449,7 +454,8 @@ public class PlayerInventory : MonoBehaviour
                     }
                 }
                 consumeWeapon = consumeWeapons[num];
-                
+                Debug.LogWarning(string.Format("{0}番目の{1}を消費するよ", num, consumeWeapon.name));
+
 
                 evolutionWeaponUpgrades.Remove(chosenWeaponUpgrade);
 
@@ -493,6 +499,7 @@ public class PlayerInventory : MonoBehaviour
 
                         upgradeOption.upgradeButton.onClick.AddListener(() => Remove(consumeWeapon, true)); // 進化前アイテムの削除
                         upgradeOption.upgradeButton.onClick.AddListener(() => availableWeaponUpgrades.Remove(consumeWeapon)); // 進化前アイテムの削除
+                        upgradeOption.upgradeButton.onClick.AddListener(() => consumeWeapons.Remove(consumeWeapon)); // 進化前アイテムの削除
                         upgradeOption.upgradeButton.onClick.AddListener(() => Add(chosenWeaponUpgrade));  //Apply button functionality
                         upgradeOption.upgradeButton.onClick.AddListener(() => evolutionWeapons.Remove(chosenWeaponUpgrade)); // 進化武器候補から削除
                         upgradeOption.upgradeDescriptionDisplay.text = chosenWeaponUpgrade.baseStats.description;  //Apply initial description


### PR DESCRIPTION
進化システムがわかりにくかったため、旭祭仕様にしたよ。
武器が最大レベルに達したとき、進化先の武器が次のレベルアップ時に選択できるようになったよ。
nullエラーも亡くなったよ。